### PR TITLE
PEP 8 compliance and further code clearness changes

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/Addon-to-FiveM-ready.iml
+++ b/.idea/Addon-to-FiveM-ready.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="Python 3.10 (Addon-to-FiveM-ready)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/discord.xml
+++ b/.idea/discord.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DiscordProjectSettings">
+    <option name="show" value="ASK" />
+    <option name="description" value="" />
+  </component>
+</project>

--- a/.idea/discord.xml
+++ b/.idea/discord.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DiscordProjectSettings">
-    <option name="show" value="ASK" />
+    <option name="show" value="PROJECT_FILES" />
     <option name="description" value="" />
   </component>
 </project>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,12 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoredPackages">
+        <value>
+          <list size="0" />
+        </value>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.10 (Addon-to-FiveM-ready)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Addon-to-FiveM-ready.iml" filepath="$PROJECT_DIR$/.idea/Addon-to-FiveM-ready.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/main.py
+++ b/main.py
@@ -149,7 +149,7 @@ if change_name.lower() == "y":
                 else:
                     os.rename(os.path.join(root, file), os.path.join(root, file.replace(vehicle_name, new_name)))
 
-    if warnings == []:
+    if not warnings:
         print("\nNo warnings\n")
     else:
         print("\n{}\n".format("\n".join(warnings)))  # no escape characters in f-string )-;

--- a/main.py
+++ b/main.py
@@ -138,13 +138,13 @@ if change_name.lower() == "y":
                         try:
                             os.rename(os.path.join(root, file),
                                       os.path.join(root, file.replace(vehicle_name, new_name)))
-                        except:
+                        except FileExistsError:
                             pass
                     elif f_name.endswith("+hi"):
                         try:
                             os.rename(os.path.join(root, file),
                                       os.path.join(root, file.replace(vehicle_name, new_name)))
-                        except:
+                        except FileExistsError:
                             pass
                 else:
                     os.rename(os.path.join(root, file), os.path.join(root, file.replace(vehicle_name, new_name)))

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ GitHub: https://github.com/zeplulw/Addon-to-FiveM-ready/
 import tkinter, os, datetime, shutil, random, subprocess
 import xml.etree.ElementTree as ET
 from tkinter import filedialog
+
 tkinter.Tk().withdraw()
 
 print("Created by zep#0012 for use anywhere. No license of any kind\n\nSelect .RPF file to convert")
@@ -20,8 +21,6 @@ folder_name = f"rpf-convert_{datetime.datetime.now().strftime('%H-%M-%S')}"
 output_path = os.path.join(os.path.dirname(rpf_path), folder_name)
 os.mkdir(output_path)
 print(f"\n--- SAVE FOLDER ---\n{folder_name}")
-
-
 
 print("\n--- START UNPACK ---")
 try:
@@ -77,7 +76,8 @@ print("\n--- DELETED ORIGINAL FOLDERS/FILES ---")
 os.rename(os.path.join(root_path, "tmp_data"), os.path.join(root_path, "data"))
 os.rename(os.path.join(root_path, "tmp_stream"), os.path.join(root_path, "stream"))
 
-vehicle_name = ET.parse(os.path.join(root_path, "data", "vehicles.meta")).getroot().find("InitDatas").find("Item").find("modelName").text
+vehicle_name = ET.parse(os.path.join(root_path, "data", "vehicles.meta")).getroot().find("InitDatas").find("Item") \
+    .find("modelName").text
 
 print(f"\nSuccessfully converted '{vehicle_name}' to FiveM ready")
 
@@ -119,7 +119,8 @@ if change_name.lower() == "y":
                 f_root.find("HandlingData").find("Item").find("handlingName").text = new_name
                 if float(f_root.find("HandlingData").find("Item").find("fMass").attrib['value']) > 5000:
                     warnings.append("!!! WARNING: The mass of this vehicle is abnormally high (>5000) !!!")
-                if "CSpecialFlightHandlingData" in f_root.find("HandlingData").find("Item").find("SubHandlingData").findall("Item"):
+                if "CSpecialFlightHandlingData" in f_root.find("HandlingData").find("Item").find("SubHandlingData") \
+                        .findall("Item"):
                     warnings.append("!!!WARNING: This vehicle has special flight handling !!!")
 
             # gta is picky so i write it in binary mode
@@ -135,21 +136,22 @@ if change_name.lower() == "y":
                 if len(f_name) != len(vehicle_name):
                     if f_name.endswith("_hi"):
                         try:
-                            os.rename(os.path.join(root, file), os.path.join(root, file.replace(vehicle_name, new_name)))
+                            os.rename(os.path.join(root, file),
+                                      os.path.join(root, file.replace(vehicle_name, new_name)))
                         except:
                             pass
                     elif f_name.endswith("+hi"):
                         try:
-                            os.rename(os.path.join(root, file), os.path.join(root, file.replace(vehicle_name, new_name)))
+                            os.rename(os.path.join(root, file),
+                                      os.path.join(root, file.replace(vehicle_name, new_name)))
                         except:
                             pass
                 else:
                     os.rename(os.path.join(root, file), os.path.join(root, file.replace(vehicle_name, new_name)))
-                        
-                        
+
     if warnings == []:
         print("\nNo warnings\n")
     else:
-        print("\n{}\n".format("\n".join(warnings))) # no escape characters in f-string )-;
+        print("\n{}\n".format("\n".join(warnings)))  # no escape characters in f-string )-;
 
     input(f"Successfully converted '{vehicle_name}' to '{new_name}'! Press enter to exit...")

--- a/main.py
+++ b/main.py
@@ -67,9 +67,9 @@ for root, dirs, files in os.walk(root_path):
     for file in files:
         if not file.endswith((".meta", ".ytd", ".yft", ".ydr", ".png", ".dds", ".bmp", ".jpg", ".jpeg")):
             os.remove(os.path.join(root, file))
-    for dir in dirs:
-        if dir not in ("tmp_data", "tmp_stream"):
-            shutil.rmtree(os.path.join(root, dir))
+    for dir_ in dirs:
+        if dir_ not in ("tmp_data", "tmp_stream"):
+            shutil.rmtree(os.path.join(root, dir_))
 
 print("\n--- DELETED ORIGINAL FOLDERS/FILES ---")
 

--- a/main.py
+++ b/main.py
@@ -25,7 +25,8 @@ print(f"\n--- SAVE FOLDER ---\n{folder_name}")
 
 print("\n--- START UNPACK ---")
 try:
-    # separated into two because PowerShell is fucking stupid and doesnt understand basic fucking sense (i spend a little time on this :D)
+    # separated into two because PowerShell is fucking stupid and doesnt understand basic fucking sense (i spend a
+    # little time on this :D)
     call = "cd 'C:/Program Files/gtautil-2.2.7';"
     call2 = f".\gtautil extractarchive --input '{rpf_path}' --output '{output_path}'"
     subprocess.run(['powershell', call, call2])


### PR DESCRIPTION
Adds compliance with PEP 8.

3518b510e1de6cb87bcac3ad24874d8fcda23ddd & a5348db4dfda7b1e83551bc6be3064771013b5e0 - Handles compliance with PEP 8 E501, namely the maximum length of a line, set to 120 characters.

801d35715d32122eb5b9115eefb915ec34f572fd - Please note that checking if a instance of a certain type is same to an empty instance of the same type is the same as utilizing that type in a boolean expression, for example:

Assuming:
```py
list1 = ["Hello, World"]
```
Aka. `list1` is a non-empty list

```py
if list1 == []:
    pass
```

is equivalent to 

```py
if list1:
    pass
```

Underlying priniciple is actually a coerced conversion of list to bool, note that
```py
bool(list1)  # True
bool([])  # False
```

Actually, in Python, any empty mutable or non-mutable iterable, when converted or coerced to bool, will present a falsy value.

a878c3f00f7b48eba74b376113a7b003ff91b88b - Note that PEP 8 E722 doesn't permit bare except clauses, deeming them too broad, and, in this case, they are not required in this specific situation.

Note that according to the Python documentation on the `os` module, [namely the `os.rename` method](https://docs.python.org/3.10/library/os.html#os.rename) explicitly declares that [`FileExistsError`](https://docs.python.org/3.10/library/exceptions.html#FileExistsError) is the only exception that can be raised on Windows.

Obviously, this program indirectly only targets Windows as `gtautil`, on which it depends, is Windows-only.

28b6e294d0f403d17cbed739564b0afc8c1b8303 - Element `dir` in for loop shadowed built-in element `dir`, PEP enforced procedure is to add a trailing underscore to avoid conflict