### PR TITLE
 chore(main): fixed work-around for two-command call 

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ print(f"\n--- SAVE FOLDER ---\n{folder_name}")
 
 print("\n--- START UNPACK ---")
 try:
-    call = f"(cd 'C:/Program Files/gtautil-2.2.7') -and (./gtautil extractarchive --input '{rpf_path}' --output '{output_path}')"
+    call = f"(cd 'C:/Program Files/gtautil-2.2.7') ; (./gtautil extractarchive --input '{rpf_path}' --output '{output_path}')"
     subprocess.run(['powershell', call])
 except Exception as e:
     print(f"Something bad happened:\n{e}")

--- a/main.py
+++ b/main.py
@@ -24,11 +24,8 @@ print(f"\n--- SAVE FOLDER ---\n{folder_name}")
 
 print("\n--- START UNPACK ---")
 try:
-    # separated into two because PowerShell is fucking stupid and doesnt understand basic fucking sense (i spend a
-    # little time on this :D)
-    call = "cd 'C:/Program Files/gtautil-2.2.7';"
-    call2 = f".\gtautil extractarchive --input '{rpf_path}' --output '{output_path}'"
-    subprocess.run(['powershell', call, call2])
+    call = f"(cd 'C:/Program Files/gtautil-2.2.7') -and (./gtautil extractarchive --input '{rpf_path}' --output '{output_path}')"
+    subprocess.run(['powershell', call])
 except Exception as e:
     print(f"Something bad happened:\n{e}")
 


### PR DESCRIPTION
Fixed two command call work-around

Note that 
```ps
(cd 'C:/Program Files/gtautil-2.2.7') -and (./gtautil extractarchive --input '{rpf_path}' --output '{output_path}')
```

Is equivalent to 

```bash
cd 'C:/Program Files/gtautil-2.2.7' && ./gtautil extractarchive --input '{rpf_path}' --output '{output_path}'
```

in bash-like systems.

